### PR TITLE
Support Null node names.

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,9 +92,10 @@ function createServer(cattle_config_url, listen_port, update_interval) {
             debug.log('got host metric results %o', hostdata)
             hostdata.map( function(item) {
                 var state = item.state
-                var hostName = getSafeName(item.name)
+                var hostName = (item.name != null) ? getSafeName(item.name) : getSafeName(item.hostname)
                 var value = (state == 'active') ? 1 : 0
-                updateGauge(hosts_gauge, { name: hostName }, value)
+                var params = item.labels + { name: hostName }
+                updateGauge(hosts_gauge, params, value)
             });
 
         });
@@ -159,7 +160,9 @@ function getEnvironmentsState(cattle_config_url, callback) {
                 var hostsData = json.data.map(function(raw) {
                     return {
                         name: raw.name,
-                        state: raw.state
+                        state: raw.state,
+                        hostname: raw.hostname,
+                        labels: raw.labels
                     }
                 });
                 next(null, servicesUrl, hostsData)


### PR DESCRIPTION
Node names are not required in Rancher. In the UI, it defaults to the hostname if not specified. Following the same rules here. 
Also, pulled in the host labels for potential use.